### PR TITLE
New option -z for late/lazy loading of amalgamed modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ table as `_G.arg`).
 
     ./amalg.lua -o out.lua -a -s main.lua -c
 
+To enable late/lazy loading of amalgated code, specify the -z flag.
+This will try to traditionally require() the modules, and
+only in case of failure it will load the amalgated version.
+This is primarily used to deploy customized versions of
+some of your modules, and have a default amalgated base
+installation of your project.
+
 That's it. For further info consult the source (there's a nice
 [annotated HTML file][6] rendered with [Docco][7] on the GitHub
 pages). Have fun!

--- a/src/amalg.lua
+++ b/src/amalg.lua
@@ -120,6 +120,13 @@
 --
 --     ./amalg.lua -o out.lua -a -s main.lua -c
 --
+-- To enable late loading of amalated code, specify the -z flag. 
+-- This will try to traditionally require() the modules, and
+-- only in case of failure it will load the amalated version.
+-- This is primarily used to deploy customized versions of
+-- some of your modules, and have a default amalgated base
+-- installation of your project.
+--
 -- That's it. For further info consult the source.
 --
 --


### PR DESCRIPTION
When specifying the -z parameter, existing lua modules in the filesystem (C or L) will be loaded instead of the amalgamed copies.
This makes it easy to provide individually patched/modified versions of your projects while sharing only one amalgamed base.