### PR TITLE
New -C commandline option to use a dedicated amalg.cache file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ commandline) using the `-c` flag.
 
     ./amalg.lua -o out.lua -s main.lua -c
 
+Or you can use the cache (in addition to all module names given on the
+commandline) using the `-C <file>` flag to use a custom cache file.
+
+    ./amalg.lua -o out.lua -s main.lua -C myamalg.cache
+
 However, this will only embed the Lua modules. To also embed C modules
 (both from the cache and from the command line), you have to specify
 the `-x` flag:

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ table as `_G.arg`).
 
     ./amalg.lua -o out.lua -a -s main.lua -c
 
+To enable late/lazy loading of amalgated code, specify the -z flag.
+This will try to traditionally require() the modules, and
+only in case of failure it will load the amalgated version.
+This is primarily used to deploy customized versions of
+some of your modules, and have a default amalgated base
+installation of your project.
+
 That's it. For further info consult the source (there's a nice
 [annotated HTML file][6] rendered with [Docco][7] on the GitHub
 pages). Have fun!

--- a/src/amalg.lua
+++ b/src/amalg.lua
@@ -120,6 +120,13 @@
 --
 --     ./amalg.lua -o out.lua -a -s main.lua -c
 --
+-- To enable late loading of amalated code, specify the -z flag. 
+-- This will try to traditionally require() the modules, and
+-- only in case of failure it will load the amalated version.
+-- This is primarily used to deploy customized versions of
+-- some of your modules, and have a default amalgated base
+-- installation of your project.
+--
 -- That's it. For further info consult the source.
 --
 --

--- a/src/amalg.lua
+++ b/src/amalg.lua
@@ -418,6 +418,15 @@ local function amalgamate( ... )
     out:write( "do\n\n" )
   end
 
+  -- Option -z: if module exists besides the amalgamed version,
+  -- load it; package.preload wont be used then.
+  if load_late then
+    out:write( [[
+      local searchers = package.searchers or package.loaders
+      table.insert(searchers, 1, searchers[2])
+      table.insert(searchers, 2, searchers[3+1])
+    ]] )
+  end
   -- Sort modules alphabetically. Modules will be embedded in
   -- alphabetical order. This ensures deterministic output.
   local module_names = {}
@@ -445,11 +454,6 @@ local function amalgamate( ... )
         modules[ m ], errors[ m ] = "C", msg
       else
         local bytes, is_bin = readluafile( path )
-        -- Option -z: if module exists besides the amalgamed version,
-        -- load it; package.preload wont be used then.
-        if load_late then
-          out:write( "pcall(require,", qformat( m ),")\n" )
-        end
         if is_bin or dbg then
           -- Precompiled Lua modules are loaded via the standard Lua
           -- function `load` (or `loadstring` in Lua 5.1). Since this


### PR DESCRIPTION
Use -C <myamalg.cache> to use this file instead of default "./amalg.cache".

Plus, some searcher magic we added back in 2018.